### PR TITLE
fix: `removesuffix` is not supported on 3.8

### DIFF
--- a/litestar_vite/commands.py
+++ b/litestar_vite/commands.py
@@ -66,14 +66,15 @@ def init_vite(
         for template_name in enabled_templates
     }
     for template_name, template in templates.items():
-        target_file_name = template_name.removesuffix(".j2")
+        target_file_name = template_name[:-3] if template_name.endswith(".j2") else template_name
         with Path(target_file_name).open(mode="w") as file:
             console.print(f" * Writing {target_file_name} to {Path(target_file_name)!s}")
 
             file.write(
                 template.render(
                     entry_point=[
-                        f"{resource_path!s}/{resource_name.removesuffix('.j2')}" for resource_name in enabled_resources
+                        f"{resource_path!s}/{resource_name[:-3] if resource_name.endswith('.j2') else resource_name}"
+                        for resource_name in enabled_resources
                     ],
                     enable_ssr=enable_ssr,
                     asset_url=asset_url,
@@ -91,9 +92,11 @@ def init_vite(
 
     for resource_name in enabled_resources:
         template = get_template(environment=vite_template_env, name=resource_name)
-        target_file_name = f"{resource_path}/{resource_name.removesuffix('.j2')}"
+        target_file_name = f"{resource_path}/{resource_name[:-3] if resource_name.endswith('.j2') else resource_name}"
         with Path(target_file_name).open(mode="w") as file:
-            console.print(f" * Writing {resource_name.removesuffix('.j2')} to {Path(target_file_name)!s}")
+            console.print(
+                f" * Writing {resource_name[:-3] if resource_name.endswith('.j2') else resource_name} to {Path(target_file_name)!s}",
+            )
             file.write(template.render())
     console.print("[yellow]Vite initialization completed.[/]")
 

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -78,11 +78,11 @@ app = Litestar(plugins=[vite])
     )
 
     assert "Initializing Vite" in result.output
-    assert Path(tmp_project_dir / "vite.config.ts").exists()
-    assert Path(tmp_project_dir / "package.json").exists()
-    assert Path(tmp_project_dir / "tsconfig.json").exists()
-    assert Path(tmp_project_dir / "resources" / "main.ts").exists()
-    assert Path(tmp_project_dir / "resources" / "styles.css").exists()
+    assert Path(Path(tmp_project_dir) / "vite.config.ts").exists()
+    assert Path(Path(tmp_project_dir) / "package.json").exists()
+    assert Path(Path(tmp_project_dir) / "tsconfig.json").exists()
+    assert Path(Path(tmp_project_dir) / "resources" / "main.ts").exists()
+    assert Path(Path(tmp_project_dir) / "resources" / "styles.css").exists()
 
 
 def test_init_install_build(


### PR DESCRIPTION
This PR implements an alternative to `removesuffix` which is not supported in Python 3.8